### PR TITLE
Add sending with pcap client

### DIFF
--- a/Pcap/NosSmooth.Pcap/PcapNostaleManager.cs
+++ b/Pcap/NosSmooth.Pcap/PcapNostaleManager.cs
@@ -99,7 +99,7 @@ public class PcapNostaleManager
         {
             foreach (var sniffedPacket in data.SniffedData)
             {
-                client.OnPacketArrival(null, connection, sniffedPacket);
+                client.OnPacketArrival(null, connection, sniffedPacket, null);
             }
         }
     }
@@ -240,9 +240,10 @@ public class PcapNostaleManager
 
         if (_clients.TryGetValue(tcpConnection, out var clients))
         {
+            var ethPacket = packet as PacketDotNet.EthernetPacket;
             foreach (var client in clients)
             {
-                client.OnPacketArrival((LibPcapLiveDevice)e.Device, tcpConnection, tcpPacket.PayloadData);
+                client.OnPacketArrival((LibPcapLiveDevice)e.Device, tcpConnection, tcpPacket.PayloadData, ethPacket);
             }
         }
     }

--- a/Pcap/NosSmooth.Pcap/ProcessTcpManager.cs
+++ b/Pcap/NosSmooth.Pcap/ProcessTcpManager.cs
@@ -109,8 +109,9 @@ public class ProcessTcpManager
             }
         }
 
-        await _semaphore.WaitAsync();
-        _connections = TcpConnectionHelper.GetConnections(_processes);
+        _semaphore.WaitAsync();
+        var processes = new List<int>(_processes);
         _semaphore.Release();
+        _connections = TcpConnectionHelper.GetConnections(processes);
     }
 }

--- a/Pcap/NosSmooth.Pcap/TcpConnectionHelper.cs
+++ b/Pcap/NosSmooth.Pcap/TcpConnectionHelper.cs
@@ -39,8 +39,18 @@ public static class TcpConnectionHelper
 
         foreach (var connection in tcpv4Connections)
         {
-            var process = processIds.FirstOrDefault(x => x == connection.OwningPid, -1);
-            if (process != -1)
+            var process = (int)connection.OwningPid;
+            var matches = false;
+            foreach (var processId in processIds)
+            {
+                if (connection.OwningPid == processId)
+                {
+                    matches = true;
+                    break;
+                }
+            }
+
+            if (matches)
             {
                 if (!result.ContainsKey(process))
                 {


### PR DESCRIPTION
An attempt to add sending with a pcap client, creating an ethernet packet with the right payload.

Currently the packet is correctly interpreted by NosSmooth, it is captured. But it does not look like it's been sent to the server or received by the client.